### PR TITLE
test-helpers: Addressing comments from hellais in PR #32

### DIFF
--- a/test-helpers/th-004-raw-tcp-echo.md
+++ b/test-helpers/th-004-raw-tcp-echo.md
@@ -1,6 +1,6 @@
 # Specification version number
 
-2014-12-08-000
+2014-12-15-000
 
 # Specification name
 
@@ -12,7 +12,7 @@ The Raw TCPEcho Test Helper listens on a TCP port for incoming connections.
 When a connection is initiated, it accepts the connection, reads a dummy HTTP
 request and sends an HTTP reply containing an encoding of the IP packets that
 made up the TCP 3 way handshake [[Wikipedia-3WHS][]] which can be compared
-against the packets sent by an ooniprobe test.
+against the packets sent by an ooni-probe meter.
 
 # Helper preconditions
 

--- a/test-helpers/th-005-raw-udp-echo.md
+++ b/test-helpers/th-005-raw-udp-echo.md
@@ -1,6 +1,6 @@
 # Specification version number
 
-2014-12-08-000
+2014-12-15-000
 
 # Specification name
 
@@ -10,7 +10,7 @@ Raw UDP Echo Test Helper
 
 The Raw UDP Echo Test Helper listens on a UDP port for incoming packets. When a
 packet is recieved, it sends a UDP packet in reply with the original packet's
-header as its payload.
+IP and UDP header and payload as the reply's payload.
 
 # Helper preconditions
 
@@ -22,9 +22,9 @@ header as its payload.
 # Expected impact
 
 Ability to help an ooni-probe client determine if the UDP header is being
-rewritten and if packets are being truncated when UDP-lite is used with a
-shorter checksum coverage than the full length of the packet using the UDP
-protocol number in the IP header.
+rewritten and if packets are being truncated when UDP-lite [[RFC3828][]] is
+used with a shorter checksum coverage than the full length of the packet using
+the UDP protocol number in the IP header.
 
 # Expected inputs
 
@@ -35,7 +35,7 @@ protocol number in the IP header.
 # Expected output
 
  * A UDP packet with the original incoming packet as its payload addressed to
-   return to the ooniprobe client
+   return to the ooni-probe meter
 
 # Possible conclusions
 
@@ -47,8 +47,23 @@ Possible conclusions that could be drawn from tests using this helper are:
    for the full length of the packet
  * Source and destination ports are being rewritten
 
+# Security considerations
+
+In order to prevent the possibility of this helper being used to set up a
+"loop" where a forged source address causes packets to be sent to another
+service that replies to arbitrary UDP packets, such as UDP echo, the first byte
+of the payload in the request must have a zero value. Replies will never have a
+zero value as this first byte contains the IP protocol version number from the
+IP header.
+
+The possibility of this helper being used for an amplification attack was
+considered, but as the amplification factor is limited to the size of an IP and
+UDP header, it was not deemed that mitigation for this was necessary.
+
 # Notes
 
 An implementation of this test helper is currently being worked on by Iain R.
 Learmonth <<irl@fsfe.org>> using Scapy.
+
+[RFC3828]: http://tools.ietf.org/html/rfc3828
 


### PR DESCRIPTION
- Corrected vocabulary for the OONI naming conventions
- Added a security considerations section to the raw UDP helper
- Added a reference for UDP-lite in the raw UDP helper
