### PR TITLE
Proposal to repurpose dns spoof test 

### DIFF
--- a/nettests/ts-005-dns-spoof.md
+++ b/nettests/ts-005-dns-spoof.md
@@ -1,62 +1,70 @@
 # Specification version number
 
-0.2.0
+0.3.0
 
 # Specification name
 
 DNS Spoof Test
 
-Note: this test is deprecated.
-
 # Test preconditions
 
   * An Internet connection.
 
-  * A DNS resolver to test against.
+  * A DNS server which will return client IP address and ISP Geoip information.
 
-  * A Hostname to resolve and check for tampering.
+  * A Hostname to resolve and check for hijacking.
 
 # Expected impact
 
-  * The ability to detect spoofed DNS responses.
+  * The ability to detect interseption of DNS traffic on operator level when DNS requests are not forwarded to requested resolver, but DNS servers of ISP are used to make request to NS server hosting DNS zone.
 
 # Expected inputs
 
 This test expects the following arguments:
 
-  * The address and port of the resolver to test.
-
+  * The address and port of the resolver to test 
   * The hostname to be resolved.
+  * expected TXT record output
 
 ## Semantics
 
-The resolver to test is passed by argument (-r) with ADDRESS:PORT convention.
-A known good backend resolver may also be passed by argument (-b) with the
-same convention.  The default known good backend resolver is Google DNS
-(8.8.8.8:53).
+The resolver to test is passed by argument (-r) with ADDRESS:PORT convention. e.g. 8.8.8.8:53
 
-The hostname to test is passed by argument (-h) as a FQDN, e.g.
-www.google.com
+The hostname to test is passed by argument (-h) as a FQDN, e.g. test.dns.google.com
+
+A known good TXT expected result to test is passed by argument (-e) e.g. "Thanks for using Google Public DNS."  
 
 # Test Description
 
-We perform an A DNS query (via UDP) to the control resolver. The answer to
-such query is called the control answer.
+We perform an TXT DNS query (via UDP) to the test resolver. We then compare
+this answer (experiment answer) with the expected answer.
 
-We perform an A DNS query (via UDP) to the test resolver. We then compare
-this answer (experiment answer) with the control answer.
-
-If the DNS payload of the received packets matches identically, then spoofing
+If the DNS payload of the received packets not matches identically, then spoofing
 is considered to be occurring.
+
+* Examples with dig utility *
+
+Google NS servers return TXT record only if request is coming from Google Public DNS servers in case if DNS request is spoofed then it returns nothing. 
+If empty answer is returned then it means that request was originated from non Google Public DNS servers.
+
+```
+dig +short @8.8.8.8 -p 53 -t txt test.dns.google.com
+"Thanks for using Google Public DNS."
+```
+
+maxmind.test-ipv6.com NS server returns client IP address and GeoIP data, which must match resolver ISP data (Google in case of 8.8.8.8)  
+
+```
+dig +short @8.8.8.8 -t txt maxmind.test-ipv6.com
+"ip='2a00:1450:4001:c11::103' as='15169' isp='GOOGLE' country='US'"
+```
+
 
 # Expected output
 
 The output report will contain a boolean entry 'spoofing'.  If spoofing is
 occurring, it shall be True. Otherwise, it is False.
 
-## Parent data format
-
-df-003-scapyt
 
 ## Required output data
 
@@ -73,7 +81,7 @@ Version 0.0.1:
 
 ## Possible conclusions
 
-Whether or not DNS spoofing is occurring for a particular FQDN.
+Whether or not DNS spoofing is occurring for a particular DNS resolver and probe's ISP network.
 
 ## Example output sample
 
@@ -84,7 +92,7 @@ Whether or not DNS spoofing is occurring for a particular FQDN.
 ###########################################
 ---
 input_hashes: []
-options: [-r, '10.211.0.10:53', -h, google.com]
+options: [-r, ‘8.8.8.8:53', -h, 'test.dns.google.com', -e, 'Thanks for using Google Public DNS.']
 probe_asn: AS2819
 probe_cc: CZ
 probe_ip: 127.0.0.1
@@ -104,49 +112,45 @@ answered_packets:
       AAABAAEAAADgAAStwizoBmdvb2dsZQNjb20AAAEAAQAAAOAABK3CLOcGZ29vZ2xlA2NvbQAAAQAB
       AAAA4AAErcIs4gZnb29nbGUDY29tAAABAAEAAADgAAStwizjBmdvb2dsZQNjb20AAAEAAQAAAOAA
       BK3CLOAGZ29vZ2xlA2NvbQAAAQABAAAA4AAErcIs4QZnb29nbGUDY29tAAABAAEAAADgAAStwizu
-    summary: 'IP / UDP / DNS Ans "173.194.44.229" '
-- - raw_packet: !!binary |
-      RbgA6J0DAABAEdQUCtMACn8AAAEANQA1ANSxxAAAgYAAAQALAAAAAAZnb29nbGUDY29tAAABAAEG
-      Z29vZ2xlA2NvbQAAAQABAAAA3wAErcIs5wZnb29nbGUDY29tAAABAAEAAADfAAStwizoBmdvb2ds
-      ZQNjb20AAAEAAQAAAN8ABK3CLOkGZ29vZ2xlA2NvbQAAAQABAAAA3wAErcIs5gZnb29nbGUDY29t
-      AAABAAEAAADfAAStwizkBmdvb2dsZQNjb20AAAEAAQAAAN8ABK3CLOUGZ29vZ2xlA2NvbQAAAQAB
-      AAAA3wAErcIs7gZnb29nbGUDY29tAAABAAEAAADfAAStwizhBmdvb2dsZQNjb20AAAEAAQAAAN8A
-      BK3CLOAGZ29vZ2xlA2NvbQAAAQABAAAA3wAErcIs4wZnb29nbGUDY29tAAABAAEAAADfAAStwizi
-    summary: 'IP / UDP / DNS Ans "173.194.44.231" '
-input: null
+    summary: 'IP / UDP / DNS Ans "Thanks for using Google Public DNS." '
 sent_packets:
 - - raw_packet: !!binary |
-      RQAAOAABAABAEeujfwAAAQgICAgANQA1ACRccgAAAQAAAQAAAAAAAAZnb29nbGUDY29tAAABAAE=
-    summary: 'IP / UDP / DNS Qry "google.com" '
-- - raw_packet: !!binary |
       RQAAOAABAABAEfDWfwAAAQrTAAoANQA1ACRhpQAAAQAAAQAAAAAAAAZnb29nbGUDY29tAAABAAE=
-    summary: 'IP / UDP / DNS Qry "google.com" '
+    summary: 'IP / UDP / DNS Qry "test.dns.google.com’" '
 spoofing: false
-test_a_lookup:
-  answered_packets:
-  - raw_packet: !!binary |
-      RbgA6J0DAABAEdQUCtMACn8AAAEANQA1ANSxxAAAgYAAAQALAAAAAAZnb29nbGUDY29tAAABAAEG
-      Z29vZ2xlA2NvbQAAAQABAAAA3wAErcIs5wZnb29nbGUDY29tAAABAAEAAADfAAStwizoBmdvb2ds
-      ZQNjb20AAAEAAQAAAN8ABK3CLOkGZ29vZ2xlA2NvbQAAAQABAAAA3wAErcIs5gZnb29nbGUDY29t
-      AAABAAEAAADfAAStwizkBmdvb2dsZQNjb20AAAEAAQAAAN8ABK3CLOUGZ29vZ2xlA2NvbQAAAQAB
-      AAAA3wAErcIs7gZnb29nbGUDY29tAAABAAEAAADfAAStwizhBmdvb2dsZQNjb20AAAEAAQAAAN8A
-      BK3CLOAGZ29vZ2xlA2NvbQAAAQABAAAA3wAErcIs4wZnb29nbGUDY29tAAABAAEAAADfAAStwizi
-    summary: 'IP / UDP / DNS Ans "173.194.44.231" '
-test_control_a_lookup:
-  answered_packets:
-  - raw_packet: !!binary |
+```
+
+```
+###########################################
+# OONI Probe Report for dns_spoof (0.3.0)
+# Sun Jun 13 15:40:41 2021
+###########################################
+---
+input_hashes: []
+options: [-r, ‘8.8.8.8:53', -h, 'maxmind.test-ipv6.com', -e, 'GOOGLE']
+probe_asn: AS2819
+probe_cc: CZ
+probe_ip: 127.0.0.1
+software_name: ooniprobe
+software_version: 1.0.0-rc3
+start_time: 1380116372.573729
+test_name: dns_spoof
+test_version: 0.3.0
+...
+---
+answer_flags: [ipsrc]
+answered_packets:
+- - raw_packet: !!binary |
       RbgA6OumAAAyEY4+CAgICH8AAAEANQA1ANSshgAAgYAAAQALAAAAAAZnb29nbGUDY29tAAABAAEG
       Z29vZ2xlA2NvbQAAAQABAAAA4AAErcIs5QZnb29nbGUDY29tAAABAAEAAADgAAStwizkBmdvb2ds
       ZQNjb20AAAEAAQAAAOAABK3CLOYGZ29vZ2xlA2NvbQAAAQABAAAA4AAErcIs6QZnb29nbGUDY29t
       AAABAAEAAADgAAStwizoBmdvb2dsZQNjb20AAAEAAQAAAOAABK3CLOcGZ29vZ2xlA2NvbQAAAQAB
       AAAA4AAErcIs4gZnb29nbGUDY29tAAABAAEAAADgAAStwizjBmdvb2dsZQNjb20AAAEAAQAAAOAA
       BK3CLOAGZ29vZ2xlA2NvbQAAAQABAAAA4AAErcIs4QZnb29nbGUDY29tAAABAAEAAADgAAStwizu
-    summary: 'IP / UDP / DNS Ans "173.194.44.229" '
-...
+    summary: 'IP / UDP / DNS Ans "ip='2a00:1450:4001:c11::103' as='15169' isp='GOOGLE' country='US'" '
+sent_packets:
+- - raw_packet: !!binary |
+      RQAAOAABAABAEfDWfwAAAQrTAAoANQA1ACRhpQAAAQAAAQAAAAAAAAZnb29nbGUDY29tAAABAAE=
+    summary: 'IP / UDP / DNS Qry "TXT maxmind.test-ipv6.com’" '
+spoofing: false
 ```
-
-# Privacy considerations
-
-As this test inherits from the Scapy template (see the Parent data format),
-the same warnings apply. In particular, ICMP error messages may contain the
-non anonymized user IP address.

--- a/nettests/ts-005-dns-spoof.md
+++ b/nettests/ts-005-dns-spoof.md
@@ -44,7 +44,7 @@ is considered to be occurring.
 
 * Examples with dig utility *
 
-Google NS servers return TXT record only if request is coming from Google Public DNS servers in case if DNS request is spoofed then it returns nothing. 
+Test against Google NS servers return TXT record only if request is coming from target Google Public DNS servers in case if DNS request is spoofed then it returns nothing. 
 If empty answer is returned then it means that request was originated from non Google Public DNS servers.
 
 ```
@@ -52,13 +52,19 @@ dig +short @8.8.8.8 -p 53 -t txt test.dns.google.com
 "Thanks for using Google Public DNS."
 ```
 
-maxmind.test-ipv6.com NS server returns client IP address and GeoIP data, which must match resolver ISP data (Google in case of 8.8.8.8)  
+Test against maxmind.test-ipv6.com NS server returns client IP address and GeoIP data, which must match target resolver ISP data (Google in case of 8.8.8.8)  
 
 ```
 dig +short @8.8.8.8 -t txt maxmind.test-ipv6.com
 "ip='2a00:1450:4001:c11::103' as='15169' isp='GOOGLE' country='US'"
 ```
 
+Test against maxmind.test-ipv6.com NS server returns client IP address and GeoIP data, which must match client IP address (can be NAT box IP address if used in ISP network).
+
+```
+dig +short -t txt maxmind.test-ipv6.com
+"ip='2a02:8100:c1:0::7:0001' as='3209' isp='VODANET International IP-Backbone of Vodafone' country='DE'"
+```
 
 # Expected output
 


### PR DESCRIPTION
Proposal to repurpose this outdated dns spoof test for two tests which can allow detect if DNS traffic is intercepted / hijacked by ISPs when reaching Public DNS servers (e.g. Google, Cloudflare, etc.).

Added examples for Google Public DNS test and backend server which reply with GeoIP data of requester IP.