### PR TITLE
add notes about response size limitations to hhfm, dash, and ndt7

### DIFF
--- a/nettests/ts-006-header-field-manipulation.md
+++ b/nettests/ts-006-header-field-manipulation.md
@@ -1,6 +1,6 @@
 # Specification version number
 
-0.2.1
+0.2.2
 
 * _status_: current
 

--- a/nettests/ts-006-header-field-manipulation.md
+++ b/nettests/ts-006-header-field-manipulation.md
@@ -207,6 +207,12 @@ headers not present in both the sent and received headers.
 }
 ```
 
+# Limitations
+
+The maximum response size is limited to 128 megabytes in order to not consume excessive
+memory on the host device. This is believed to be a conservative maximum bounds
+which should not be exceeded in normal usage.
+
 # Privacy considerations
 
 If the user is behind a transparent HTTP proxy that sets the X-Forwarded-For

--- a/nettests/ts-021-dash.md
+++ b/nettests/ts-021-dash.md
@@ -164,6 +164,8 @@ used by OONI Probe:
   in reality because a server cannot encode a video into all the possible
   bitrates, but is useful to measure network performance, as explained below).
 
+- each response may not exceed 128 megabytes in size.
+
 ## Rationale of selected parameters
 
 The initial bitrate estimate is set to 3,000 kbit/s because that
@@ -193,6 +195,10 @@ selecting the highest available bitrate that was lower than the
 speed with which the last segment was downloaded. In OONI Probe,
 we decided to disable this behavior by default, so to better measure
 the network quality.
+
+Response sizes are limited to 128 megabytes in order to not consume excessive
+memory on the host device. This is believed to be a conservative maximum bounds
+which should not be exceeded in normal usage.
 
 # Expected output
 

--- a/nettests/ts-021-dash.md
+++ b/nettests/ts-021-dash.md
@@ -1,6 +1,6 @@
 # Specification version number
 
-2020-04-20-001
+2025-12-01-001
 
 * _status_: current
 

--- a/nettests/ts-022-ndt.md
+++ b/nettests/ts-022-ndt.md
@@ -43,6 +43,10 @@ the following features. Ndt5 tests have a `"test_s2c"` key that is not
 present inside of ndt7 tests. Ndt7 clients also include a key that is
 called `"protocol"` and is set to `7`.
 
+Response size of each segment is limited to 128 megabytes in order to not
+consume excessive memory on the host device. This is believed to be a
+conservative maximum bounds which should not be exceeded in normal usage.
+
 # Expected output
 
 ## Parent data format

--- a/nettests/ts-022-ndt.md
+++ b/nettests/ts-022-ndt.md
@@ -1,6 +1,6 @@
 # Specification version number
 
-2020-04-08-001
+2025-12-01-001
 
 * _status_: current
 


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/spec/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe-cli/issues/1757
- [x] related ooni/probe-cli pull request: https://github.com/ooni/probe-cli/pull/1758
- [x] If I changed a spec, I also bumped its version number and/or date

<!-- Location of the issue tracker: https://github.com/ooni/probe -->

## Description

This change notes limitations of maximum response size in affected tests.
